### PR TITLE
mod_labelcollapsed: Prevent unsupported css placement from breaking 'Default activitiy completion' page

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -30,11 +30,14 @@ require_once($CFG->dirroot.'/course/moodleform_mod.php');
 
 $PAGE->requires->jquery();
 $PAGE->requires->js('/mod/labelcollapsed/js/colourpicker/jquery.simplecolorpicker.min.js', true);
-$PAGE->requires->css('/mod/labelcollapsed/simplecolorpicker.css');
 
 class mod_labelcollapsed_mod_form extends moodleform_mod {
 
     public function definition() {
+        global $PAGE;
+
+        $PAGE->requires->css('/mod/labelcollapsed/simplecolorpicker.css');
+
         $mform = $this->_form;
         $mform->addElement('html', '<div class="form-group row  fitem">');
         $mform->addElement('html', '<div class="col-md-3"><label for="id_sectioncolor_choice">');


### PR DESCRIPTION
Moodle no longer supports the usage of `$PAGE->requires->css(...)` to inject plugin CSS. It throws an exception if the plugin trys to do this - this exception is caught and handled properly in various places, but not when the call is simply inlined in the global scope.

If we move the call down and put it within the method definition, the exception can be caught.

It should be noted that this unhandled exception is causing an error to break the 'Default activity completion' settings page on all course pages. Unsure of when it started, but it is a problem that needs to addressed for at least Moodle 4.3.